### PR TITLE
remove namespace and key parameters from vnode signature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe": "~0.2.0",
     "purescript-dom": "~0.1.1"
   }
 }

--- a/examples/Test.purs
+++ b/examples/Test.purs
@@ -1,22 +1,41 @@
 module Test where
 
-import Data.Maybe
 import VirtualDOM
 import VirtualDOM.VTree
 import Debug.Trace
 
+
 doc1 :: VTree
-doc1 = vnode "div" {} [vtext "hello"] Nothing Nothing
+doc1 = vnode "div" {} [vtext "hello"]
 
 doc2 :: VTree
-doc2 = vnode "div" {} [vtext "hello", vtext "world"] Nothing Nothing
+doc2 = vnode "div" {} [vtext "hello", vtext "world"]
 
 doc3 :: VTree
 doc3 = vtext "hello world"
+
+doc4 :: VTree
+doc4 = vnode "div" 
+    { "namespace": "http://www.w3.org/2000/svg"
+    , "key": "my key"
+    } [vtext "Am I SVG?"]
+
+doc5 :: VTree
+doc5 = vnode "div"
+    { "key": "another key"
+    , "namespace": "http://www.w3.org/1999/xhtml"
+    , "style": { "color":  "red"
+               , "height": "10px"
+               , "width":  "100px"
+               }
+           } [vtext "I do it with style."]
 
 main = do
   print doc1
   print doc2
   print doc3
+  print doc4
+  print doc5
+  
   print $ diff doc1 doc2
   print $ diff doc1 doc3

--- a/src/VirtualDOM/VTree.purs
+++ b/src/VirtualDOM/VTree.purs
@@ -1,15 +1,11 @@
 module VirtualDOM.VTree
   ( VTree()
   , TagName()
-  , Key()
-  , Namespace()
   , vnode
   , vtext
   ) where
 
 import Data.Function
-import Data.Maybe
-
 foreign import data VTree :: *
 
 foreign import showVTreeImpl
@@ -19,24 +15,32 @@ instance showVTree :: Show VTree where
   show = showVTreeImpl
 
 type TagName = String
-type Key = String
-type Namespace = String
-
-foreign import unsafeNull
-  "var unsafeNull = null;" :: forall a. a
 
 foreign import vnode' """
   var vnode$prime = (function() {
     var VNode = require('vtree/vnode');
-    return function (name, props, children, key, ns) {
+   
+    return function (name, props, children) {
+      var key = undefined;
+      var ns = undefined;
+
+      if(props.namespace) {
+        ns = props.namespace;
+        props.namespace = undefined;
+      }
+
+      if(props.key) {
+        key = props.key;
+        props.key = undefined;
+      }
+
       return new VNode(name, props, children, key, ns);
     };
   }());
-  """ :: forall props. Fn5 TagName { | props } [VTree] Key Namespace VTree
+  """ :: forall props. Fn3 TagName { | props} [VTree] VTree
 
-vnode :: forall props. TagName -> { | props } -> [VTree] -> Maybe Key -> Maybe Namespace -> VTree
-vnode name props children key ns =
-  runFn5 vnode' name props children (fromMaybe unsafeNull key) (fromMaybe unsafeNull ns)
+vnode :: forall props. TagName -> { | props} -> [VTree] -> VTree
+vnode name props children = runFn3 vnode' name props children
 
 foreign import vtext """
   var vtext = (function() {


### PR DESCRIPTION
just a little cosmetic change to extract the namespace and the key of a vnode from the properties parameter instead of using two Maybe String.

It just makes the code look better and makes it lighter to use as most of the time these two parameters are not used.
