### PR TITLE
The Meltdown: Migrating to PureScript 0.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,10 @@
     "package.json"
   ],
   "dependencies": {
+    "purescript-prelude": "^0.1.1",
+    "purescript-functions": "^0.1.0",
+    "purescript-eff": "^0.1.0",
     "purescript-dom": "~0.1.1",
-    "purescript-maybe":"~0.2.1"
+    "purescript-maybe":"^0.3.4"
   }
 }

--- a/src/VirtualDOM.js
+++ b/src/VirtualDOM.js
@@ -1,0 +1,16 @@
+"use strict";
+
+// module VirtualDOM
+
+exports.showPatchObjectImpl = JSON.stringify;
+
+exports.createElement = require('virtual-dom/create-element');
+
+exports.diff_ = require('virtual-dom/diff');
+
+exports.patch_ = require('virtual-dom/patch');
+
+exports.mkEff = function (action) {
+    return action;
+};
+

--- a/src/VirtualDOM.js
+++ b/src/VirtualDOM.js
@@ -8,9 +8,9 @@ exports.createElement = require('virtual-dom/create-element');
 
 exports.diff_ = require('virtual-dom/diff');
 
-exports.patch_ = require('virtual-dom/patch');
-
-exports.mkEff = function (action) {
-    return action;
+exports.patch_ = function (n, p) {
+    var patch = require('virtual-dom/patch');
+    return function () {
+        return patch(n, p);
+    };
 };
-

--- a/src/VirtualDOM.purs
+++ b/src/VirtualDOM.purs
@@ -27,9 +27,7 @@ foreign import diff_ :: Fn2 VTree VTree PatchObject
 diff :: VTree -> VTree -> PatchObject
 diff = runFn2 diff_
 
-foreign import patch_ :: Fn2 Node PatchObject Node
+foreign import patch_ :: forall e. Fn2 Node PatchObject (Eff (dom :: DOM | e) Node)
 
 patch :: forall e. PatchObject -> Node -> Eff (dom :: DOM | e) Node
-patch p n = mkEff \_ -> runFn2 patch_ n p
-
-foreign import mkEff :: forall eff a. (Unit -> a) -> Eff eff a
+patch p n = runFn2 patch_ n p

--- a/src/VirtualDOM.purs
+++ b/src/VirtualDOM.purs
@@ -15,29 +15,21 @@ import VirtualDOM.VTree
 -- operation.  See virtual-dom/docs.jsig for details.                             
 foreign import data PatchObject :: *
 
-foreign import showPatchObjectImpl
-  "var showPatchObjectImpl = JSON.stringify;" :: PatchObject -> String
+foreign import showPatchObjectImpl :: PatchObject -> String
 
 instance showPatchObject :: Show PatchObject where
   show = showPatchObjectImpl
 
-foreign import createElement
-  "var createElement = require('virtual-dom/create-element');" :: VTree -> Node
+foreign import createElement :: VTree -> Node
 
-foreign import diff'
-  "var diff$prime = require('virtual-dom/diff');" :: Fn2 VTree VTree PatchObject
+foreign import diff_ :: Fn2 VTree VTree PatchObject
 
 diff :: VTree -> VTree -> PatchObject
-diff = runFn2 diff'
+diff = runFn2 diff_
 
-foreign import patch'
-  "var patch$prime = require('virtual-dom/patch');" :: Fn2 Node PatchObject Node
+foreign import patch_ :: Fn2 Node PatchObject Node
 
 patch :: forall e. PatchObject -> Node -> Eff (dom :: DOM | e) Node
-patch p n = mkEff \_ -> runFn2 patch' n p
+patch p n = mkEff \_ -> runFn2 patch_ n p
 
-foreign import mkEff """
-  function mkEff(action) {
-    return action;
-  }
-  """ :: forall eff a. (Unit -> a) -> Eff eff a
+foreign import mkEff :: forall eff a. (Unit -> a) -> Eff eff a

--- a/src/VirtualDOM.purs
+++ b/src/VirtualDOM.purs
@@ -5,6 +5,7 @@ module VirtualDOM
   , patch
   ) where
 
+import Prelude
 import Control.Monad.Eff
 import Data.Function
 import DOM

--- a/src/VirtualDOM/VTree.js
+++ b/src/VirtualDOM/VTree.js
@@ -1,0 +1,72 @@
+"use strict";
+
+// module VirtualDOM.VTree
+
+exports.showVTreeImpl = JSON.stringify;
+
+exports.vnode_ = function() {
+    var VNode = require('virtual-dom/vnode/vnode');
+   
+    return function (name, props, children) {
+      var key = undefined;
+      var ns = undefined;
+
+      if(props.namespace) {
+        ns = props.namespace;
+        props.namespace = undefined;
+      }
+
+      if(props.key) {
+        key = props.key;
+        props.key = undefined;
+      }
+
+      return new VNode(name, props, children, key, ns);
+    };
+}();
+
+exports.vtext = function() {
+    var VText = require('virtual-dom/vnode/vtext');
+    return function (text) {
+      return new VText(text);
+    };
+}();
+
+exports.widget = function() { 
+    return function (props) {
+      var rWidget = { type: 'Widget'};
+       
+      if(props.init)    { rWidget.init    = props.init };
+      if(props.update)  { rWidget.update  = props.update }; 
+      if(props.destroy) { rWidget.destroy = props.destroy };
+
+      return rWidget;
+    };
+}();
+
+exports.thunk_ = function() { 
+    return function (renderFn, nothing, just) {
+      var rThunk  = { type: 'Thunk'
+                    , render: function(prevNode) { 
+                                if (prevNode === null)
+                                  return renderFn(nothing);
+                                else
+                                  return renderFn(just(prevNode));
+                              }
+                    };
+      // No need for vnode here.  It is used internally by virtual-dom to cache
+      // the result of render.
+      return rThunk;
+    };
+}();
+
+exports.vhook = function() { 
+    return function (props) {
+      var rVHook  = function () { };
+      if(props.hook)   { rVHook.prototype.hook    = props.hook };
+      if(props.unhook) { rVHook.prototype.unhook  = props.unhook }; 
+      return new rVHook;
+    };
+}();
+
+exports.showVHookImpl = JSON.stringify;

--- a/src/VirtualDOM/VTree.purs
+++ b/src/VirtualDOM/VTree.purs
@@ -15,106 +15,39 @@ import Data.Maybe
 
 foreign import data VTree :: *
 
-foreign import showVTreeImpl
-  "var showVTreeImpl = JSON.stringify;" :: VTree -> String
+foreign import showVTreeImpl :: VTree -> String
 
 instance showVTree :: Show VTree where
   show = showVTreeImpl
 
 type TagName = String
 
-foreign import vnode' """
-  var vnode$prime = (function() {
-    var VNode = require('virtual-dom/vnode/vnode');
-   
-    return function (name, props, children) {
-      var key = undefined;
-      var ns = undefined;
+foreign import vnode_ :: forall props. Fn3 TagName { | props} (Array VTree) VTree
 
-      if(props.namespace) {
-        ns = props.namespace;
-        props.namespace = undefined;
-      }
+vnode :: forall props. TagName -> { | props} -> Array VTree -> VTree
+vnode name props children = runFn3 vnode_ name props children
 
-      if(props.key) {
-        key = props.key;
-        props.key = undefined;
-      }
+foreign import vtext :: String -> VTree
 
-      return new VNode(name, props, children, key, ns);
-    };
-  }());
-  """ :: forall props. Fn3 TagName { | props} [VTree] VTree
+foreign import widget :: forall props. { | props} -> VTree
 
-vnode :: forall props. TagName -> { | props} -> [VTree] -> VTree
-vnode name props children = runFn3 vnode' name props children
-
-foreign import vtext """
-  var vtext = (function() {
-    var VText = require('virtual-dom/vnode/vtext');
-    return function (text) {
-      return new VText(text);
-    };
-  }());
-  """ :: String -> VTree
-
-foreign import widget """
-  var widget = (function() { 
-    return function (props) {
-      var rWidget = { type: 'Widget'};
-       
-      if(props.init)    { rWidget.init    = props.init };
-      if(props.update)  { rWidget.update  = props.update }; 
-      if(props.destroy) { rWidget.destroy = props.destroy };
-
-      return rWidget;
-    };
-  }());
-  """ :: forall props. { | props} -> VTree
-
-foreign import thunk'  """
-  var thunk$prime  = (function() { 
-    return function (renderFn, nothing, just) {
-      var rThunk  = { type: 'Thunk'
-                    , render: function(prevNode) { 
-                                if (prevNode === null)
-                                  return renderFn(nothing);
-                                else
-                                  return renderFn(just(prevNode));
-                              }
-                    };
-      // No need for vnode here.  It is used internally by virtual-dom to cache
-      // the result of render.
-      return rThunk;
-    };
-  }());
-  """ :: Fn3  (Maybe VTree -> VTree) 
-              (Maybe VTree) 
-              (VTree -> Maybe VTree) 
-              VTree
+foreign import thunk_ :: Fn3  (Maybe VTree -> VTree) 
+                              (Maybe VTree) 
+                              (VTree -> Maybe VTree) 
+                              VTree
 
 -- Render a VTree using custom logic function.  The logic can examine the 
 -- previous VTree before returning the new (or same) one.  The result of the 
 -- render function must be a vnode, vtext, or widget.  This constraint is not
 -- enforced by the types.
 thunk :: (Maybe VTree -> VTree) -> VTree
-thunk render = runFn3 thunk' render Nothing Just
+thunk render = runFn3 thunk_ render Nothing Just
 
 foreign import data VHook :: *
 
-foreign import vhook  """
-  var vhook  = (function() { 
-    return function (props) {
-      var rVHook  = function () { };
-      if(props.hook)   { rVHook.prototype.hook    = props.hook };
-      if(props.unhook) { rVHook.prototype.unhook  = props.unhook }; 
-      return new rVHook;
-    };
-  }());
-  """ :: forall props. { | props } -> VHook
+foreign import vhook  :: forall props. { | props } -> VHook
 
-foreign import showVHookImpl
-  "var showVHookImpl = JSON.stringify;" :: VHook -> String
+foreign import showVHookImpl :: VHook -> String
 
 instance showVHook :: Show VHook where
   show = showVHookImpl

--- a/src/VirtualDOM/VTree.purs
+++ b/src/VirtualDOM/VTree.purs
@@ -9,6 +9,7 @@ module VirtualDOM.VTree
   , vhook
   ) where
 
+import Prelude
 import Data.Function
 import Data.Maybe
 


### PR DESCRIPTION
I wanted to try using virtual-dom from PureScript and I found that this library hasn't been updated for PureScript 0.7, so here is my attempt at doing that.

Since this library does not seem to be used any more, would you know what is currently the preferred way to traverse and manipulate the DOM as an immutable data structure from PureScript?
